### PR TITLE
Introduce ArchUnit to enforce architectural boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Spring configuration is Java-based (`RestConfig`, `PersistenceConfig`) — there
 mvn clean install
 ```
 
-The build runs unit tests and enforces a minimum 50% JaCoCo code coverage threshold. CI runs the same check on every pull request.
+The build runs unit tests, enforces a minimum 50% JaCoCo code coverage threshold on the domain module, and checks seven ArchUnit architectural rules. CI runs the same checks on every pull request.
 
 ## Running locally
 

--- a/budinv-controller/pom.xml
+++ b/budinv-controller/pom.xml
@@ -49,5 +49,12 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit5</artifactId>
+			<version>${archunit.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/budinv-controller/src/test/java/com/joragupra/budinv/architecture/ArchitectureTest.java
+++ b/budinv-controller/src/test/java/com/joragupra/budinv/architecture/ArchitectureTest.java
@@ -1,0 +1,96 @@
+package com.joragupra.budinv.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.file.Paths;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+class ArchitectureTest {
+
+    private static final String DOMAIN_PACKAGE = "..domain..";
+    private static final String DTO_PACKAGE = "..dto..";
+    private static final String ENTITY_PACKAGE = "..entity..";
+    private static final String REPOSITORY_PACKAGE = "..repository..";
+
+    private static JavaClasses projectClasses;
+
+    @BeforeAll
+    static void importClasses() {
+        projectClasses = new ClassFileImporter()
+                .withImportOption(new ImportOption.DoNotIncludeTests())
+                .importPaths(
+                        Paths.get("target/classes"),
+                        Paths.get("../budinv-model/target/classes"),
+                        Paths.get("../budinv-infrastructure/target/classes")
+                );
+    }
+
+    @Test
+    void domain_is_free_of_framework_dependencies() {
+        noClasses().that().resideInAPackage(DOMAIN_PACKAGE)
+                .should().dependOnClassesThat().resideInAnyPackage(
+                        "org.springframework..",
+                        "jakarta.persistence..",
+                        "com.fasterxml.jackson..",
+                        "jakarta.xml.bind.."
+                )
+                .because("the domain model must remain framework-agnostic")
+                .check(projectClasses);
+    }
+
+    @Test
+    void domain_does_not_depend_on_dto() {
+        noClasses().that().resideInAPackage(DOMAIN_PACKAGE)
+                .should().dependOnClassesThat().resideInAPackage(DTO_PACKAGE)
+                .because("the domain model must not depend on its HTTP representation")
+                .check(projectClasses);
+    }
+
+    @Test
+    void domain_does_not_depend_on_entities() {
+        noClasses().that().resideInAPackage(DOMAIN_PACKAGE)
+                .should().dependOnClassesThat().resideInAPackage(ENTITY_PACKAGE)
+                .because("the domain model must not depend on JPA entities")
+                .check(projectClasses);
+    }
+
+    @Test
+    void rest_controllers_reside_in_root_package() {
+        classes().that().areAnnotatedWith(RestController.class)
+                .should().resideInAPackage("com.joragupra.budinv")
+                .because("REST controllers belong to the HTTP layer root package")
+                .check(projectClasses);
+    }
+
+    @Test
+    void jpa_entities_reside_in_entity_package() {
+        classes().that().areAnnotatedWith("jakarta.persistence.Entity")
+                .should().resideInAPackage(ENTITY_PACKAGE)
+                .because("JPA entities must be confined to the infrastructure entity package")
+                .check(projectClasses);
+    }
+
+    @Test
+    void repositories_reside_in_repository_package() {
+        classes().that().areInterfaces()
+                .and().areAssignableTo("org.springframework.data.repository.Repository")
+                .should().resideInAPackage(REPOSITORY_PACKAGE)
+                .because("Spring Data repositories must be confined to the infrastructure repository package")
+                .check(projectClasses);
+    }
+
+    @Test
+    void controllers_do_not_use_jpa_entities() {
+        noClasses().that().areAnnotatedWith(RestController.class)
+                .should().dependOnClassesThat().resideInAPackage(ENTITY_PACKAGE)
+                .because("controllers must interact with the domain model, not JPA entities directly")
+                .check(projectClasses);
+    }
+}

--- a/docs/adrs/0013-archunit-architecture-tests.md
+++ b/docs/adrs/0013-archunit-architecture-tests.md
@@ -1,0 +1,34 @@
+# 13. ArchUnit for enforcing architectural rules
+
+Date: 2026-05-16
+
+## Status
+
+Accepted
+
+## Context
+
+The five-module Maven structure and the package conventions that separate domain, DTO, entity, and repository classes are enforced only by convention. Nothing in the build prevents a developer from adding a Spring annotation to a domain class or accessing a JPA entity directly from a controller. Violations of these boundaries would be discovered late, if at all.
+
+## Decision
+
+Introduce [ArchUnit](https://www.archunit.org) (`archunit-junit5` 1.3.0) as a test dependency in `budinv-controller`. That module has the widest classpath visibility — it depends on both `budinv-model` and `budinv-infrastructure` — making it the natural host for cross-module architectural rules. Tests are written as plain JUnit 5 `@Test` methods using a `ClassFileImporter` that scans the compiled output of the three Java modules at test time.
+
+Seven rules are enforced:
+
+1. Domain classes (`..domain..`) must not import Spring, JPA, Jackson, or JAXB.
+2. Domain classes must not depend on DTO classes.
+3. Domain classes must not depend on JPA entity classes.
+4. `@RestController` classes must reside in the root package `com.joragupra.budinv`.
+5. `@Entity` classes must reside in `..entity..`.
+6. Spring Data `Repository` interfaces must reside in `..repository..`.
+7. `@RestController` classes must not directly use JPA entity classes.
+
+As a direct consequence of introducing ArchUnit 1.3.0, the project's Java compile target was reduced from 25 to 21. ArchUnit's bundled ASM library does not yet support Java 25 class files (major version 69), and the codebase uses no Java 25-specific language features, making Java 21 (the current LTS) a safe target.
+
+## Consequences
+
+- Architectural boundary violations are caught at build time, not in code review.
+- ArchUnit tests do not contribute to JaCoCo coverage metrics, because they analyse bytecode statically without executing production code.
+- The Java compile target is 21, not 25. This should be revisited when a version of ArchUnit compatible with Java 25 class files is available.
+- New architectural conventions must be accompanied by a corresponding ArchUnit rule to be considered enforced.

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <junit.version>5.13.0</junit.version>
     <jacoco.version>0.8.13</jacoco.version>
     <cargo.version>1.10.15</cargo.version>
+    <archunit.version>1.3.0</archunit.version>
   </properties>
 
   <dependencyManagement>
@@ -116,7 +117,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
         <configuration>
-          <release>25</release>
+          <release>21</release>
           <showWarnings>true</showWarnings>
         </configuration>
       </plugin>


### PR DESCRIPTION
Adds 7 ArchUnit rules in budinv-controller covering domain purity, package placement of entities/repositories/controllers, and the prohibition on controllers accessing JPA entities directly.

The compile target is reduced from 25 to 21 because ArchUnit 1.3.0 bundles an ASM version that cannot read Java 25 class files; the codebase uses no Java 25-specific language features.